### PR TITLE
fix: add "d.servedPath" config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,13 +58,18 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Is dub project"
+                },
+                "d.servedPath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Path to serve-d binary"
                 }
             }
         },
         "commands": [
             {
                 "command": "code-d.Command",
-                "title": "d command title"
+                "title": "D command title"
             }
         ]
     }


### PR DESCRIPTION
We are checking for this here: https://github.com/vushu/coc-dlang/blob/1ddd26cabc6aa2e708d91b1dc2d7fce23fff7408/src/index.ts#L36

But we are not providing it as a valid config option for CoC to recognise from `coc-settings.json`. This PR adds it as a user-facing config option.