### PR TITLE
fix: download only one binary for latest release

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 const homedir = require('os').homedir();
 const extensionsFolder = path.join(homedir, '.config', 'coc', 'extensions', 'coc-dlang-data');
-const latestServedUrl = "https://api.github.com/repos/Pure-D/serve-d/releases/latest";
+const latestStableUrl = "https://api.github.com/repos/Pure-D/serve-d/releases/latest";
 const latestPrereleaseUrl = "https://api.github.com/repos/Pure-D/serve-d/releases";
 const serveDSourceCodeUrl = "https://github.com/Pure-D/serve-d/archive/refs/heads/master.zip"
 const filename = 'serve-d-master'
@@ -39,10 +39,10 @@ function createDownloadConfig(remoteFilename: string) {
 export async function installLanguageServer(extensionsFolder: string): Promise<void | undefined> {
   window.showQuickpick(['use latest stable release', 'use latest pre-release', 'build directly from repository'], 'Select serve-d version').then(chosen => {
     if (chosen === 0) {
-      downloadLastestStable();
+      downloadLatestStable();
     }
     else if (chosen === 1) {
-      downloadPrereleaseServed();
+      downloadLatestPrerelease();
     }
     else {
       // serve-d doesn't download to extensionFolder so we do this manually
@@ -51,16 +51,16 @@ export async function installLanguageServer(extensionsFolder: string): Promise<v
   });
 }
 
-export async function downloadPrereleaseServed(): Promise<string | undefined> {
+export async function downloadLatestPrerelease(): Promise<string | undefined> {
   const downloadConfig = createDownloadConfig("serve-d");
-  const commando = `curl -s ${latestPrereleaseUrl} | grep browser_download_url | grep ${downloadConfig.file} | cut -d '"' -f 4 |  head -n 1 | wget -qi - -P ${downloadConfig.outputPath} && cd ${downloadConfig.outputPath} && ${downloadConfig.extractCommand} && ${downloadConfig.cleanupCommand}`
+  const commando = `cd ${downloadConfig.outputPath} && curl -s ${latestPrereleaseUrl} | grep browser_download_url | grep ${downloadConfig.file} | cut -d '"' -f 4 |  head -n 1 | xargs curl -sLO && ${downloadConfig.extractCommand} && ${downloadConfig.cleanupCommand}`
   return downloadFromGithub(downloadConfig, commando);
 }
 
-export async function downloadLastestStable(): Promise<string | undefined> {
+export async function downloadLatestStable(): Promise<string | undefined> {
 
   const downloadConfig = createDownloadConfig("serve-d");
-  const commando = `curl -s ${latestPrereleaseUrl} | grep browser_download_url | grep ${downloadConfig.file} | cut -d '"' -f 4 | wget -qi - -P ${downloadConfig.outputPath} && cd ${downloadConfig.outputPath} && ${downloadConfig.extractCommand} && ${downloadConfig.cleanupCommand}`
+  const commando = `cd ${downloadConfig.outputPath} && curl -s ${latestStableUrl} | grep browser_download_url | grep ${downloadConfig.file} | cut -d '"' -f 4 |  head -n 1 | xargs curl -sLO && ${downloadConfig.extractCommand} && ${downloadConfig.cleanupCommand}`
   return downloadFromGithub(downloadConfig, commando);
 }
 

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -89,7 +89,7 @@ export async function buildFromRepository(data): Promise<boolean | undefined> {
   let deleteOldDirectoryIfExists = `rm -rf ${pathToServedBuildFolder}`;
   let cleanupCommand = `rm ${filename}.zip`;
   let extractCommand = `unzip -qq ${filename}.zip`;
-  const commando = `${deleteOldFileIfExists} && ${deleteOldDirectoryIfExists} && wget --content-disposition --quiet ${serveDSourceCodeUrl} -P ${extensionsFolder} && cd ${extensionsFolder} && ${extractCommand} && ${cleanupCommand}`;
+  const commando = `${deleteOldFileIfExists} && ${deleteOldDirectoryIfExists} && cd ${extensionsFolder} && curl -sLO ${serveDSourceCodeUrl} && ${extractCommand} && ${cleanupCommand}`;
   const execPromise = util.promisify(exec);
   let success = false;
 


### PR DESCRIPTION
This PR fixes the bug that downloaded multiple binaries for the stable version of serve-d (missing `head -n 1`). It also replaces the dependency of `wget` with `curl`, ensuring that coc-clangd will work on machines that do not have `wget` installed. `xargs` is available as a part of GNU findutils, and will be installed by default on systems much more commonly than wget.

Closes #4 